### PR TITLE
ContactDataHandler: include email ids.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -106,6 +106,7 @@ class ContactDataHandler extends Handler {
   text(opts) {
     switch (this.tagName) {
       case "address":
+      case "id":
       case "number":
       case "location":
         this[this.tagName] = opts
@@ -118,6 +119,7 @@ class ContactDataHandler extends Handler {
     switch (name) {
       case "email-address":
         this.emails.push({
+          id: this.id,
           address: this.address,
           location: this.location
         })

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ describe('Highrise', () => {
     it('should parse person records', (done) => {
       readToParser('test/examples/person.xml', new Parser()).then((person) => {
         assert.equal('Partner', person.tags[0].name)
+        person.emails.forEach(e => assert.isDefined(e.id))
         done()
       }).catch((err) => {
         console.log(err.stack)


### PR DESCRIPTION
- We need the `id` field for patch/delete operations.
- Includes a test for the presence of the `id` field.
